### PR TITLE
Add ability to create db2 instance and fence users with forcelocal

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ db2::install { '10.5':
 * `instance_user_home`: Home directory of the instance user
 * `type`: Type of product this instance is for (default: ese)
 * `auth`: Type of auth for this instance (default: server)
+* `users_forcelocal`: Force the creation of instance and fence users to be local
 
 ## `db2`
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ db2::install { '10.5':
 * `instance_user_home`: Home directory of the instance user
 * `type`: Type of product this instance is for (default: ese)
 * `auth`: Type of auth for this instance (default: server)
-* `users_forcelocal`: Force the creation of instance and fence users to be local
+* `users_forcelocal`: Force the creation of instance and fence users to be local, true or false. (default: undef)
 
 ## `db2`
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -14,6 +14,7 @@ define db2::instance (
   $instance_user_uid    = undef,
   $instance_user_gid    = undef,
   $instance_user_home   = undef,
+  $users_forcelocal     = undef,
   $type                 = 'ese',
   $auth                 = 'server',
 ) {
@@ -24,6 +25,7 @@ define db2::instance (
       uid        => $fence_user_uid,
       gid        => $fence_user_gid,
       home       => $fence_user_home,
+      forcelocal => $users_forcelocal,
       managehome => true,
       before     => Exec["db2::instance::${name}"],
     }
@@ -34,6 +36,7 @@ define db2::instance (
       uid        => $instance_user_uid,
       gid        => $instance_user_gid,
       home       => $instance_user_home,
+      forcelocal => $users_forcelocal,
       managehome => true,
       before     => Exec["db2::instance::${name}"],
     }


### PR DESCRIPTION
Reference: #1 

This adds a `users_forcelocal` parameter which causes the fence and instance users to be created with `forcelocal`
