### PR TITLE
Changes to allow for Runtime client to be configured.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,9 +15,7 @@ class db2 (
   $workspace     = '/var/puppet_db2',
 ) {
 
-  file { $workspace:
-    ensure => directory,
-  }
+  ensure_resource("file", $workspace, { "ensure" => "directory" })
 
   create_resources('db2::install', $installations)
   create_resources('db2::instance', $instances)

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -3,8 +3,8 @@
 # Set up a DB2 instance
 #
 define db2::instance (
-  $fence_user,
   $installation_root,
+  $fence_user           = undef,
   $instance_user        = $name,
   $manage_fence_user    = true,
   $manage_instance_user = true,
@@ -15,19 +15,22 @@ define db2::instance (
   $instance_user_gid    = undef,
   $instance_user_home   = undef,
   $users_forcelocal     = undef,
+  $port                 = undef,
   $type                 = 'ese',
   $auth                 = 'server',
 ) {
 
   if $manage_fence_user {
-    user { $fence_user:
-      ensure     => present,
-      uid        => $fence_user_uid,
-      gid        => $fence_user_gid,
-      home       => $fence_user_home,
-      forcelocal => $users_forcelocal,
-      managehome => true,
-      before     => Exec["db2::instance::${name}"],
+    if $fence_user {
+      user { $fence_user:
+        ensure     => present,
+        uid        => $fence_user_uid,
+        gid        => $fence_user_gid,
+        home       => $fence_user_home,
+        forcelocal => $users_forcelocal,
+        managehome => true,
+        before     => Exec["db2::instance::${name}"],
+      }
     }
   }
   if $manage_instance_user {
@@ -42,9 +45,22 @@ define db2::instance (
     }
   }
 
+  if ( $fence_user )  {
+    $fence_user_flag = "-u ${fence_user}"
+  } else {
+    $fence_user_flag = ''
+  }
+
+  if ( $port ) {
+    $port_flag = "-p ${port}"
+  } else {
+    $port_flag = ""
+  }
+
+
   exec { "db2::instance::${name}":
     path    => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-    command => "${installation_root}/instance/db2icrt -s ${type} -a ${auth} -u ${fence_user} ${instance_user}",
+    command => "${installation_root}/instance/db2icrt -s ${type} -a ${auth} ${fence_user_flag} ${port_flag} ${instance_user}",
     unless  => "${installation_root}/instance/db2ilist ${instance_user}"
   }
 }

--- a/tests/rtc.pp
+++ b/tests/rtc.pp
@@ -1,0 +1,19 @@
+class { 'db2':
+  installations => {
+    '11.1' => {
+      'source' => '/vagrant/ibm_data_server_runtime_client_linuxx64_v11.1.tar.gz',
+      'product' => 'RUNTIME_CLIENT',
+      'components' => [ 'JAVA_SUPPORT', 'LDAP_EXPLOITATION', 'BASE_CLIENT' ],
+      'configure_license' => false,
+    }
+  },
+  instances => {
+    'db2crgd' => {
+      'instance_user_uid' => '10011',
+      'type' => 'client',
+      'installation_root' => '/opt/ibm/db2/V11.1',
+     }
+  },
+}
+
+      


### PR DESCRIPTION
This commit makes some default settings assumptions including those
for RTC (run time client) and makes the fence_user flag for db2icrt
optional to allow for db2 runtime instances to be created.

Also added optional port parameter (closes: #4)