### PR TITLE
Added db2_exec_nofail and support for admin nodes

### DIFF
--- a/lib/puppet/provider/db2.rb
+++ b/lib/puppet/provider/db2.rb
@@ -19,21 +19,29 @@ class Puppet::Provider::Db2 < Puppet::Provider
   # directory and runs it in the correct DB2 instance by setting the
   # DB2INSTANCE environment variable.
   #
-  def db2_exec(*args)
+  def db2_instance_exec(command, failonfail=true)
     envhash = { "DB2INSTANCE" => @resource[:instance]}
     rootdir = @resource[:install_root]
     executable = File.join(rootdir, 'bin', 'db2')
 
-    command = [ executable, args ].flatten.join(" ")
+    command = [ executable, command ].flatten.join(" ")
 
     self.debug("Using custom environment #{envhash}")
-    exec_db2_command(command, envhash)
+    exec_db2_command(command, envhash, failonfail)
   end
 
-  def exec_db2_command(command,envhash = {})
+  def db2_exec(*args)
+    db2_instance_exec(args.flatten.join(" "))
+  end
+
+  def db2_exec_nofail(*args)
+    db2_instance_exec(args.flatten.join(" "), false)
+  end
+
+  def exec_db2_command(command,envhash = {}, failonfail=true)
     output = Puppet::Util::Execution.execute(
       command,
-      :failonfail => true,
+      :failonfail => failonfail,
       :custom_environment => envhash
     )
   end

--- a/lib/puppet/provider/db2_catalog_database/db2.rb
+++ b/lib/puppet/provider/db2_catalog_database/db2.rb
@@ -12,7 +12,7 @@ Puppet::Type.type(:db2_catalog_database).provide(:db2, :parent => Puppet::Provid
   end
 
   def get_databases
-    output = db2_exec('list database directory')
+    output = db2_exec_nofail('list database directory')
     parse_output(output, :as_alias, {
       /Database alias/ => :as_alias,
       /Database name/  => :db_name,

--- a/lib/puppet/provider/db2_catalog_dcs/db2.rb
+++ b/lib/puppet/provider/db2_catalog_dcs/db2.rb
@@ -2,7 +2,7 @@ require File.join(File.dirname(__FILE__), '..', 'db2.rb')
 Puppet::Type.type(:db2_catalog_dcs).provide(:db2, :parent => Puppet::Provider::Db2) do
 
   def get_dcs
-    output = db2_exec('list dcs directory')
+    output = db2_exec_nofail('list dcs directory')
     parse_output(output, :name, {
       /Local database name/ => :name,
       /Target database name/ => :target

--- a/spec/unit/puppet/type/db2_catalog_database_spec.rb
+++ b/spec/unit/puppet/type/db2_catalog_database_spec.rb
@@ -67,8 +67,8 @@ describe Puppet::Type.type(:db2_catalog_database) do
         let(:provider) { resource.provider }
 
         it "should execute the correct db2 commands" do
-          provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 #{scenario[:expect]}", { "DB2INSTANCE" => "db2inst" })
-          provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 terminate", { "DB2INSTANCE" => "db2inst" })
+          provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 #{scenario[:expect]}", { "DB2INSTANCE" => "db2inst" }, true)
+          provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 terminate", { "DB2INSTANCE" => "db2inst" }, true)
           provider.create
         end
       end

--- a/spec/unit/puppet/type/db2_catalog_node_spec.rb
+++ b/spec/unit/puppet/type/db2_catalog_node_spec.rb
@@ -138,8 +138,8 @@ describe Puppet::Type.type(:db2_catalog_node) do
         let(:provider) { resource.provider }
 
         it "should execute the correct db2 commands" do
-          provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 #{scenario[:expect]}", { "DB2INSTANCE" => "db2inst" })
-          provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 terminate", { "DB2INSTANCE" => "db2inst" })
+          provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 #{scenario[:expect]}", { "DB2INSTANCE" => "db2inst" }, true)
+          provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 terminate", { "DB2INSTANCE" => "db2inst" }, true)
           provider.create
         end
       end


### PR DESCRIPTION

### Fix errors when configuring a new instance

When a newly created instance is configured, puppet fails when
determining whether or not nodes, dcs and database entries exist because
the command "`db2 LIST * DIRECTORY`" will cause db2 to throw an error
because the directory doesn't exist.  There are various scenarios here
so the best way is to allow `db2_exec` to fail when being called from the
exists? method.  Therefore all exists? methods now call `db2_exec_nofail`

### Fix idempotency problems with admin node entries

Previously, any nodes added as `admin => true` would cause puppet to try
and configure them again on the next run, that's because we need to
separate commands to list the configured nodes, list node directory and
list admin node directory.  This commit adds support to the
`db2_catalog_node` provider to query both types of node entry and return a
unified result.