### PR TITLE
Dont force validation on type and auth.

### DIFF
--- a/lib/puppet/type/db2_catalog_node.rb
+++ b/lib/puppet/type/db2_catalog_node.rb
@@ -10,7 +10,6 @@ Puppet::Type.newtype(:db2_catalog_node) do
     [
       :install_root,
       :instance,
-      :type,
     ].each do |param|
       if self[param].nil?
         raise ArgumentError, "Must supply parameter #{param}"

--- a/lib/puppet/type/db2_instance.rb
+++ b/lib/puppet/type/db2_instance.rb
@@ -10,8 +10,6 @@ Puppet::Type.newtype(:db2_instance) do
   validate do
     [
       :install_root,
-      :auth,
-      :type,
     ].each do |param|
       if self[param].nil?
         raise ArgumentError, "Must supply parameter #{param}"


### PR DESCRIPTION

This breaks when using minimal attributes and `ensure => absent`
