### PR TITLE
Feature releases for 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,6 @@ db2::instances:
 
 Numerous native types and providers exist to manage aspects of DB2 instances, these are documented below
 
-## Limitations
-
-Currently all providers support a `create` and `destroy` method so they may be created with `ensure => present` and will be removed with `ensure => absent`.  The configurable attributes for each type (eg: auth, target, server..etc) are currently parameters in Puppet, not properties, therefore they only have an effect on resource creation.  Changing the attributes after the resource has been created will not actually change the configured state.   In order to change the configured state you need to remove them and re-create them.  Some attributes are easier than others to be able to identify change, this is functionality that will be introduced at a later date.
-
-
 ## `db2_instance`
 
 Configures a DB2 instance.   The instance user must already exist (the `db2::instance` defined type does this for you).  

--- a/lib/puppet/provider/db2.rb
+++ b/lib/puppet/provider/db2.rb
@@ -2,18 +2,6 @@ require 'puppet/provider'
 
 class Puppet::Provider::Db2 < Puppet::Provider
 
-  attr_reader :node
-  attr_reader :database
-  attr_reader :dcs
-
-  def initialize(*args)
-    @node = {}
-    @database = {}
-    @dcs = {}
-    super
-  end
-
-
   # db2_exec.
   # This method calls the db2 command located under the install_root
   # directory and runs it in the correct DB2 instance by setting the
@@ -51,6 +39,15 @@ class Puppet::Provider::Db2 < Puppet::Provider
   #
   def db2_terminate
     db2_exec('terminate')
+  end
+
+  # The flush method will be called if any properties are identified as changed.
+  # DB2 doesn't support any method for modifying an existing catalog entry so
+  # we need to uncatalog and re-create the entry
+  #
+  def flush
+    destroy
+    create
   end
 
   # Generic handler to parse the output from db2 list * directory commands.

--- a/lib/puppet/provider/db2_catalog_database/db2.rb
+++ b/lib/puppet/provider/db2_catalog_database/db2.rb
@@ -1,10 +1,12 @@
 require File.join(File.dirname(__FILE__), '..', 'db2.rb')
 Puppet::Type.type(:db2_catalog_database).provide(:db2, :parent => Puppet::Provider::Db2) do
 
+  mk_resource_methods
+
   def exists?
     databases = get_databases
     if databases.has_key?(@resource[:as_alias])
-      database=databases[@resource[:as_alias]]
+      @property_hash = databases[@resource[:as_alias]]
       true
     else
       false
@@ -17,7 +19,9 @@ Puppet::Type.type(:db2_catalog_database).provide(:db2, :parent => Puppet::Provid
       /Database alias/ => :as_alias,
       /Database name/  => :db_name,
       /Node name/ => :node,
-      /Comment/ => :comment
+      /Comment/ => :comment,
+      /Authentication/ => :authentication,
+      /Local database directory/ => :path,
     })
   end
 
@@ -33,11 +37,25 @@ Puppet::Type.type(:db2_catalog_database).provide(:db2, :parent => Puppet::Provid
     args << [ 'AT NODE', @resource[:node] ] if @resource[:node]
     args << [ 'ON', @resource[:path] ] if @resource[:path]
     args << [ 'AUTHENTICATION', @resource[:authentication] ] if @resource[:authentication]
-    args << "WITH \"#{@resource[:comment]}\"" if @resource[:comment]
+    args << "WITH '\"#{@resource[:comment]}\"'" if @resource[:comment]
     db2_exec(args)
     db2_terminate
   end
   
+  # This is a strange patch that may need addressing.  DB2 supports adding an authentication type
+  # of 'dcs', but this option is not documented on the official CLP commands documentation for
+  # the CATALOG DATABASE command.  When configured with dcs, LIST DB DIRECTORY shows the database
+  # configured as 'SERVER'.  The only workaround for the moment is to override the authentication
+  # method to report that the property is in sync if it set to SERVER but DCS is requested.
+  #
+  def authentication
+    if @property_hash[:authentication] == 'SERVER' and @resource[:authentication].upcase == 'DCS'
+      return @resource[:authentication]
+    else
+      return @property_hash[:authentication]
+    end
+  end
+
 
   def destroy
     args = [ 'UNCATALOG DATABASE' ]

--- a/lib/puppet/provider/db2_catalog_dcs/db2.rb
+++ b/lib/puppet/provider/db2_catalog_dcs/db2.rb
@@ -1,18 +1,23 @@
 require File.join(File.dirname(__FILE__), '..', 'db2.rb')
 Puppet::Type.type(:db2_catalog_dcs).provide(:db2, :parent => Puppet::Provider::Db2) do
 
+  mk_resource_methods
+
   def get_dcs
     output = db2_exec_nofail('list dcs directory')
     parse_output(output, :name, {
       /Local database name/ => :name,
-      /Target database name/ => :target
+      /Target database name/ => :target,
+      /Application requestor name/ => :ar_library,
+      /DCS parameters/ => :params,
+      /Comment/ => :comment
     })
   end
 
   def exists?
     dcs_entries = get_dcs
     if dcs_entries.has_key?(@resource[:name])
-      dcs = dcs_entries[@resource[:name]]
+      @property_hash = dcs_entries[@resource[:name]]
       true
     else
       false
@@ -28,14 +33,14 @@ Puppet::Type.type(:db2_catalog_dcs).provide(:db2, :parent => Puppet::Provider::D
     args << [ 'DATABASE', @resource[:name] ]
     args << [ 'AS', @resource[:target] ] if @resource[:target]
     args << [ 'AR', @resource[:ar_library] ] if @resource[:ar_library]
-    args << [ 'PARAMS', @resource[:params] ] if @resource[:params]
-    args << "WITH \"#{@resource[:comment]}\"" if @resource[:comment]
+    args << [ 'PARMS', "'\"#{@resource[:params]}\"'" ] if @resource[:params]
+    args << "WITH '\"#{@resource[:comment]}\"'" if @resource[:comment]
     db2_exec(args)
     db2_terminate
   end
 
   def destroy
-    args = [ 'UNCATALOG', 'DCS', @resource[:name] ]
+    args = [ 'UNCATALOG', 'DCS', 'DATABASE', @resource[:name] ]
     db2_exec(args)
     db2_terminate
   end

--- a/lib/puppet/provider/db2_catalog_node/db2.rb
+++ b/lib/puppet/provider/db2_catalog_node/db2.rb
@@ -1,10 +1,12 @@
 require File.join(File.dirname(__FILE__), '..', 'db2.rb')
 Puppet::Type.type(:db2_catalog_node).provide(:db2, :parent => Puppet::Provider::Db2) do
 
+  mk_resource_methods
+
   def exists?
     nodes = get_nodes
     if nodes.has_key?(resource[:name])
-      node=nodes[resource[:name]]
+      @property_hash = nodes[resource[:name]]
       true
     else
       false
@@ -17,11 +19,12 @@ Puppet::Type.type(:db2_catalog_node).provide(:db2, :parent => Puppet::Provider::
       /Comment/               => :comment,
       /Protocol/              => :protocol,
       /Hostname/              => :remote,
-      /Service name/          => :service,
+      /Service name/          => :server,
       /Security type/         => :security,
       /Remote instance name/  => :remote_instance,
       /System/                => :system,
-      /Operating system type/ => :ostype
+      /Operating system type/ => :ostype,
+      /Instance name/         => :to_instance,
     }
 
     # Get the raw output of both regular and admin nodes, there is no single
@@ -57,7 +60,7 @@ Puppet::Type.type(:db2_catalog_node).provide(:db2, :parent => Puppet::Provider::
       args << "REMOTE_INSTANCE #{@resource[:remote_instance]}" if @resource[:remote_instance]
       args << "SYSTEM #{@resource[:system]}" if @resource[:system]
       args << "OSTYPE #{@resource[:ostype]}" if @resource[:ostype]
-      args << "WITH \"#{@resource[:comment]}\"" if @resource[:comment]
+      args << "WITH '\"#{@resource[:comment]}\"'" if @resource[:comment]
     when 'local'
       args << 'ADMIN' if @resource[:admin]
       args << 'LOCAL NODE'
@@ -65,7 +68,7 @@ Puppet::Type.type(:db2_catalog_node).provide(:db2, :parent => Puppet::Provider::
       args << "INSTANCE #{@resource[:to_instance]}" if @resource[:to_instance]
       args << "SYSTEM #{@resource[:system]}" if @resource[:system]
       args << "OSTYPE #{@resource[:ostype]}" if @resource[:ostype]
-      args << "WITH \"#{@resource[:comment]}\"" if @resource[:comment]
+      args << "WITH '\"#{@resource[:comment]}\"'" if @resource[:comment]
     end
 
     db2_exec(args)
@@ -78,7 +81,6 @@ Puppet::Type.type(:db2_catalog_node).provide(:db2, :parent => Puppet::Provider::
     db2_exec(args)
     db2_terminate
   end
-
 end
 
 

--- a/lib/puppet/type/db2_catalog_database.rb
+++ b/lib/puppet/type/db2_catalog_database.rb
@@ -49,28 +49,26 @@ Puppet::Type.newtype(:db2_catalog_database) do
     desc "The alias of the database to be cataloged"
   end
 
-  newparam(:db_name) do
+  newproperty(:db_name) do
     desc %q{
       The database name to catalog, if this option is ommited then the name of
       the resource title (or as_alias) will be used.
     }
   end
 
-
-
-  newparam(:path) do
+  newproperty(:path) do
     desc "Specify the drive or path where the database resides"
   end
 
-  newparam(:node) do
+  newproperty(:node) do
     desc "Specify the name of the database partition server where the database resides"
   end
 
-  newparam(:authentication) do
+  newproperty(:authentication) do
     desc "Specify an authentication type for local databases.  eg: SERVER, CLIENT, SERVER_ENCRYPT"
   end
 
-  newparam(:comment) do
+  newproperty(:comment) do
     desc "A description of the catalog entry"
   end
 

--- a/lib/puppet/type/db2_catalog_dcs.rb
+++ b/lib/puppet/type/db2_catalog_dcs.rb
@@ -32,19 +32,22 @@ Puppet::Type.newtype(:db2_catalog_dcs) do
     desc "The path to the root of the DB2 installation"
   end
 
-  newparam(:target) do
+  newproperty(:target) do
     desc "Specifies the name of the target system to catalog"
+    munge do |value|
+      value.upcase
+    end
   end
 
-  newparam(:ar_library) do
+  newproperty(:ar_library) do
     desc "The name of the AR library to load.  Do not specify if using DB2 Connect"
   end
 
-  newparam(:params) do
+  newproperty(:params) do
     desc "Parameters to pass to the application requestor (AR) library"
   end
 
-  newparam(:comment) do
+  newproperty(:comment) do
     desc "A description of the catalog entry"
   end
 

--- a/lib/puppet/type/db2_catalog_node.rb
+++ b/lib/puppet/type/db2_catalog_node.rb
@@ -15,6 +15,14 @@ Puppet::Type.newtype(:db2_catalog_node) do
         raise ArgumentError, "Must supply parameter #{param}"
       end
     end
+
+    if self[:to_instance] and self[:type] != 'local'
+      raise ArgumentError, 'to_instance can only be used for local nodes'
+    end
+
+    if self[:admin] and self[:server]
+      raise ArgumentError, 'server is not a valid option for an admin node'
+    end
   end
 
   ensurable do
@@ -28,10 +36,6 @@ Puppet::Type.newtype(:db2_catalog_node) do
     desc "Specifies the DB2 instance to use, the username must match the instance name"
   end
 
-  newparam(:to_instance) do
-    desc "Name of the instance referred to in the catalog command, not the instance that we are configuring"
-  end
-
   newparam(:install_root) do
     desc "The path to the root of the DB2 installation"
   end
@@ -43,41 +47,42 @@ Puppet::Type.newtype(:db2_catalog_node) do
     end
   end
 
-  newparam(:admin, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newproperty(:to_instance) do
+    desc "Name of the instance referred to in the catalog command, not the instance that we are configuring (local only)"
+  end
+
+  newproperty(:admin, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc "When set to true specifies an administration server (tcpip only)"
   end
 
-  newparam(:remote) do
+  newproperty(:remote) do
     desc "The hostname or IP address where the database resides (tcpip only)"
   end
 
-  newparam(:server) do
+  newproperty(:server) do
     desc "Specifies the service name or port number of the database manager instance (tcpip only)"
-    validate do |value|
-      raise ArgumentError, "server cannot be specified when admin is true" if @resource[:admin] and value
-    end
   end
 
-  newparam(:security) do
+  newproperty(:security) do
     desc "Specifies the node will be security enabled, valid values are ssl, ns and server"
     munge do |value|
       value.downcase
     end
   end
 
-  newparam(:remote_instance) do
+  newproperty(:remote_instance) do
     desc "Specifies the name of the server instance where the database resides"
   end
 
-  newparam(:system) do
+  newproperty(:system) do
     desc "Specifies the DB2 system name that is used to identify the server machine"
   end
 
-  newparam(:ostype) do
+  newproperty(:ostype) do
     desc "Specifies the operating system of the server"
   end
 
-  newparam(:comment) do
+  newproperty(:comment) do
     desc "A description of the catalog entry"
   end
 

--- a/spec/unit/puppet/type/db2_catalog_dcs_spec.rb
+++ b/spec/unit/puppet/type/db2_catalog_dcs_spec.rb
@@ -6,13 +6,23 @@ describe Puppet::Type.type(:db2_catalog_dcs) do
     [
       :instance,
       :install_root,
+      :name,
+    ].each do |param|
+      it "should have a #{param} parameter" do
+        expect(described_class.attrtype(param)).to eq(:param)
+      end
+    end
+  end
+
+  context 'property' do
+    [
       :target,
       :ar_library,
       :params,
       :comment
     ].each do |param|
-      it "should have a #{param} parameter" do
-        expect(described_class.attrtype(param)).to eq(:param)
+      it "should have a #{param} property" do
+        expect(described_class.attrtype(param)).to eq(:property)
       end
     end
   end
@@ -37,5 +47,75 @@ describe Puppet::Type.type(:db2_catalog_dcs) do
   end
 
   context 'when declared with minimal params' do
+    it "should compile" do
+      expect do
+        described_class.new(
+          :name => 'db2inst',
+          :install_root => 'foo',
+          :instance => 'bar',
+        ).not_to raise_error
+      end
+    end
   end
+
+  describe "provider" do
+    scenarios = [
+      {
+      :name => "With minimal configuration",
+      :with => {}, 
+      :expect => 'CATALOG DCS DATABASE db2db'
+      },
+      {
+      :name => "With target",
+      :with => {:target => 'db2target'}, 
+      :expect => 'CATALOG DCS DATABASE db2db AS DB2TARGET'
+      },
+      {
+      :name => "With application requestor",
+      :with => {:target => 'db2target', :ar_library => 'arlib', :params => 'arparam'}, 
+      :expect => 'CATALOG DCS DATABASE db2db AS DB2TARGET AR arlib PARMS \'"arparam"\''
+      },
+      {
+      :name => "With comment",
+      :with => {:target => 'db2target', :ar_library => 'arlib', :params => 'arparam', :comment => "dcs description"}, 
+      :expect => 'CATALOG DCS DATABASE db2db AS DB2TARGET AR arlib PARMS \'"arparam"\' WITH \'"dcs description"\''
+      },
+    ]
+    
+    scenarios.each do |scenario|
+      context scenario[:name] do
+        let(:resource) {
+          described_class.new(
+            scenario[:with].merge({ :name => 'db2db', :instance => 'db2inst', :install_root => '/opt/ibm/db2/V11.1'})
+          )
+        }
+        let(:provider) { resource.provider }
+
+        it "should execute the correct db2 commands" do
+          provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 #{scenario[:expect]}", { "DB2INSTANCE" => "db2inst" }, true)
+          provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 terminate", { "DB2INSTANCE" => "db2inst" }, true)
+          provider.create
+        end
+      end
+    end
+
+    context "destroying" do
+      let(:resource) {
+        described_class.new(
+          :name => 'db2db',
+          :ensure => 'absent',
+          :install_root => '/opt/ibm/db2/V11.1',
+          :instance   => 'db2inst'
+         )
+      }
+      let(:provider) { resource.provider }
+      it "should uncatalog the node" do
+        provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 UNCATALOG DCS DATABASE db2db", { "DB2INSTANCE" => "db2inst" }, true)
+        provider.expects(:exec_db2_command).with("/opt/ibm/db2/V11.1/bin/db2 terminate", { "DB2INSTANCE" => "db2inst" }, true)
+        provider.destroy
+      end
+    end
+
+  end
+
 end


### PR DESCRIPTION

### Feature

* Attributes for `db2_catalog_node`, `db2_catalog_database` and `db2_catalog_dcs` are now puppet properties, rather than parameters, which means Puppet will now enforce changes after creation and maintain the state of the catalog entries... eg:

```
Notice: /Stage[main]/Db2/Db2::Instance[db2test4]/Db2_catalog_node[DB2NODE1]/remote: remote changed 'db12.example.com' to 'db15.example.com'
```

This addresses the idempotency limitations of the resource types. Previously Puppet would use the attributes to create the catalog entry but if they were later changed in Puppet, it would not enforce the changes.  

### Bugfixes

* Bugfix: quotes for `comment` attribute and `params` attributes
* Bugfix: renamed `PARAMS` to `PARMS` for the catalog_dcs provider

### Other

* Fixed some validation issues with types
* Added more spec tests

