### PR TITLE
Give more verbose error if db2::install is declared before db2, ref #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Some warnings can be ignored, please see the IBM documentation for more informat
 
 # Usage
 
-This module includes two defined resource types, `db2::install` and `db2::instance`.  `db2::install` is a defined resource type, and not a class, because it's possible to install multiple versions of DB2 server side by side on the same server, so this module allows for that.
+This module includes two defined resource types, `db2::install` and `db2::instance`.  `db2::install` is a defined resource type, and not a class, because it's possible to install multiple versions of DB2 server side by side on the same server, so this module allows for that.  Note that the `db2` baseclass must be included before declaring `db2::instance` types in your manifests in order for certain variables and dependencies to be set.
 
 This module has only been tested for DB2 10.5, but should work for earlier versions
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,6 +19,11 @@ define db2::install (
   $license_source    = undef,
 ) {
 
+  # db2 class must be included before db2::install
+  if !defined(Class['::db2']) {
+    fail('The baseclass db2 must be included before declaring db2::install')
+  }
+
   # Set up file locations
 
   # Based on the product we try and set some sensible defaults for 


### PR DESCRIPTION

The `db2` base class must be included before `db2::install` but this wasn't documented and Puppet throws a non-obvious error about `$db2::workspace` being an unknown variable.  This PR adds some docs and a fail condition to `db2::instance` to make this more clear.