### PR TITLE
Remove tarball and extracted files after installation is finished.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -97,9 +97,24 @@ define db2::install (
       source       => $source,
       extract_path => $installer_root,
       before       => Exec["db2::install::${name}"],
+      creates      => $p_install_dest, # this prevents us using cleanup => true
+    }
+
+    # Cleanup after installation is finished
+    file { "Remove ${binpath}":
+        ensure  => absent,
+        path    => $binpath,
+        recurse => true,
+        purge   => true,
+        force   => true, # remove also directories
+        require => Exec["db2::install::${name}"],
+    }
+    file { "Remove ${installer_root}/${p_filename}":
+        ensure  => absent,
+        path    => "${installer_root}/${p_filename}",
+        require => Exec["db2::install::${name}"],
     }
   }
-
 
   file { $responsefile:
     ensure  => file,


### PR DESCRIPTION
If $extract is true, this module can leave behind multiple gigs of unnecessary installation data. Tarball and extracted files should be removed after installation is finished.

- New 'creates' variable in archive prevents downloading the tarball after installation is successful. It also prevents us using 'cleanup' functionality of archive to remove the tarball because it expects that the 'creates' directory exists before cleanup will be done.
- Two new file {ensure => absent} resources will remove the tarball and extracted files.