### PR TITLE
Better handling of cleaning up archive files (#20)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
   - PUPPET_VERSION="~> 4.5.0"
   - PUPPET_VERSION="~> 4.6.1"
   - PUPPET_VERSION="~> 4.7.0"
+  - PUPPET_VERSION="~> 4.8.0"
+  - PUPPET_VERSION="~> 4.9.2"
+  - PUPPET_VERSION="~> 4.10.0"
 rvm:
   - 1.9.3
   - 2.0

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ gem 'facter', '>= 1.7.0'
 if RUBY_VERSION < '2.0'
   gem 'json', '~> 1.8'
   gem 'json_pure', '~> 1.8'
+  gem 'parallel_tests', '~> 1.9'
 end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -101,17 +101,15 @@ define db2::install (
     }
 
     # Cleanup after installation is finished
-    file { "Remove ${binpath}":
+    file { $binpath:
         ensure  => absent,
-        path    => $binpath,
         recurse => true,
         purge   => true,
         force   => true, # remove also directories
         require => Exec["db2::install::${name}"],
     }
-    file { "Remove ${installer_root}/${p_filename}":
+    file { "${installer_root}/${p_filename}":
         ensure  => absent,
-        path    => "${installer_root}/${p_filename}",
         require => Exec["db2::install::${name}"],
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -97,9 +97,24 @@ define db2::install (
       source       => $source,
       extract_path => $installer_root,
       before       => Exec["db2::install::${name}"],
+      creates      => $p_install_dest, # this prevents us using cleanup => true
+    }
+
+    # Cleanup after installation is finished
+    file { "Remove ${binpath}":
+        ensure  => absent,
+        path    => $binpath,
+        recurse => true,
+        purge   => true,
+        force   => true, # remove also directories
+        require => Exec["db2::install::${name}"],
+    }
+    file { "Remove ${installer_root}/${p_filename}":
+        ensure  => absent,
+        path    => "${installer_root}/${p_filename}",
+        require => Exec["db2::install::${name}"],
     }
   }
-
 
   file { $responsefile:
     ensure  => file,

--- a/spec/defines/install_spec.rb
+++ b/spec/defines/install_spec.rb
@@ -203,6 +203,15 @@ describe 'db2::install' do
       it do 
         is_expected.not_to contain_archive('/var/puppet_db2/db2.tar.gz')
       end
+
+      it do
+        is_expected.not_to contain_file('/var/puppet_db2/db2.tar.gz')
+      end
+
+      it do
+        is_expected.not_to contain_file('/var/puppet_db2/universal')
+      end
+
     end
   end
 

--- a/spec/defines/install_spec.rb
+++ b/spec/defines/install_spec.rb
@@ -18,12 +18,112 @@ describe 'db2::install' do
         is_expected.to contain_archive('/var/puppet_db2/v11.1_linux64_expc.tar.gz').with(
           :extract => true,
           :source  => 'http://foo/v11.1_linux64_expc.tar.gz',
-          :extract_path => '/var/puppet_db2'
+          :extract_path => '/var/puppet_db2',
+          :creates => '/opt/ibm/db2/V11.1'
         ).that_comes_before('Exec[db2::install::11.1]')
       end
 
       it do
         is_expected.to contain_file('/var/puppet_db2/11.1.rsp')
+      end
+
+      it do
+        is_expected.to contain_file('/var/puppet_db2/universal').with(
+          :ensure => :absent,
+          :purge => :true,
+          :force => :true
+        ).that_requires('Exec[db2::install::11.1]')
+      end
+
+      it do
+        is_expected.to contain_file('/var/puppet_db2/v11.1_linux64_expc.tar.gz').with(
+          :ensure => :absent
+        ).that_requires('Exec[db2::install::11.1]')
+      end
+    end
+    context "when configuring a different version with title" do
+      let(:title) { '12.1' }
+      let(:params) {{
+        :configure_license => false,
+        :source            => 'http://foo/v12.1_linux64_expc.tar.gz',
+      }}
+    
+      it do 
+        is_expected.to contain_archive('/var/puppet_db2/v12.1_linux64_expc.tar.gz').with(
+          :extract => true,
+          :source  => 'http://foo/v12.1_linux64_expc.tar.gz',
+          :extract_path => '/var/puppet_db2',
+          :creates => '/opt/ibm/db2/V12.1'
+        ).that_comes_before('Exec[db2::install::12.1]')
+      end
+
+      it do
+        is_expected.to contain_file('/var/puppet_db2/12.1.rsp')
+      end
+
+      it do
+        is_expected.to contain_file('/var/puppet_db2/universal').with(
+          :ensure => :absent,
+          :purge => :true,
+          :force => :true
+        ).that_requires('Exec[db2::install::12.1]')
+      end
+
+      it do
+        is_expected.to contain_file('/var/puppet_db2/v12.1_linux64_expc.tar.gz').with(
+          :ensure => :absent
+        ).that_requires('Exec[db2::install::12.1]')
+      end
+    end
+    context "when configuring a different version with the version parameter" do
+      let(:title) { 'db2_install' }
+      let(:params) {{
+        :configure_license => false,
+        :source            => 'http://foo/v12.1_linux64_expc.tar.gz',
+        :version           => '12.1',
+      }}
+    
+      it do 
+        is_expected.to contain_archive('/var/puppet_db2/v12.1_linux64_expc.tar.gz').with(
+          :extract => true,
+          :source  => 'http://foo/v12.1_linux64_expc.tar.gz',
+          :extract_path => '/var/puppet_db2',
+          :creates => '/opt/ibm/db2/V12.1'
+        ).that_comes_before('Exec[db2::install::db2_install]')
+      end
+
+      it do
+        is_expected.to contain_file('/var/puppet_db2/db2_install.rsp')
+      end
+
+      it do
+        is_expected.to contain_file('/var/puppet_db2/universal').with(
+          :ensure => :absent,
+          :purge => :true,
+          :force => :true
+        ).that_requires('Exec[db2::install::db2_install]')
+      end
+
+      it do
+        is_expected.to contain_file('/var/puppet_db2/v12.1_linux64_expc.tar.gz').with(
+          :ensure => :absent
+        ).that_requires('Exec[db2::install::db2_install]')
+      end
+    end
+    context "when extracting tarball with a custom installer folder" do
+      let(:title) { '11.1' }
+      let(:params) {{
+        :configure_license => false,
+        :source            => 'http://foo/v11.1_linux64_expc.tar.gz',
+        :installer_folder  => 'server_t'
+      }}
+    
+      it do
+        is_expected.to contain_file('/var/puppet_db2/server_t').with(
+          :ensure => :absent,
+          :purge => :true,
+          :force => :true
+        ).that_requires('Exec[db2::install::11.1]')
       end
     end
     context "when extracting tarball to a custom filename" do
@@ -38,10 +138,25 @@ describe 'db2::install' do
         is_expected.to contain_archive('/var/puppet_db2/db2.tar.gz').with(
           :extract => true,
           :source  => 'http://foo/v11.1_linux64_expc.tar.gz',
-          :extract_path => '/var/puppet_db2'
+          :extract_path => '/var/puppet_db2',
+          :creates => '/opt/ibm/db2/V11.1'
         ).that_comes_before('Exec[db2::install::11.1]')
       end
+      it do
+        is_expected.to contain_file('/var/puppet_db2/universal').with(
+          :ensure => :absent,
+          :purge => :true,
+          :force => :true
+        ).that_requires('Exec[db2::install::11.1]')
+      end
+
+      it do
+        is_expected.to contain_file('/var/puppet_db2/db2.tar.gz').with(
+          :ensure => :absent
+        ).that_requires('Exec[db2::install::11.1]')
+      end
     end
+
     context "when extracting tarball to a custom installer root" do
       let(:title) { '11.1' }
       let(:params) {{
@@ -55,12 +170,26 @@ describe 'db2::install' do
         is_expected.to contain_archive('/var/installers/db2/db2.tar.gz').with(
           :extract => true,
           :source  => 'http://foo/v11.1_linux64_expc.tar.gz',
-          :extract_path => '/var/installers/db2'
+          :extract_path => '/var/installers/db2',
+          :creates => '/opt/ibm/db2/V11.1'
         ).that_comes_before('Exec[db2::install::11.1]')
       end
 
       it do
         is_expected.to contain_file('/var/installers/db2/11.1.rsp')
+      end
+      it do
+        is_expected.to contain_file('/var/installers/db2/universal').with(
+          :ensure => :absent,
+          :purge => :true,
+          :force => :true
+        ).that_requires('Exec[db2::install::11.1]')
+      end
+
+      it do
+        is_expected.to contain_file('/var/installers/db2/db2.tar.gz').with(
+          :ensure => :absent
+        ).that_requires('Exec[db2::install::11.1]')
       end
     end
     context "when extract is set to false" do


### PR DESCRIPTION

Incorporates changes introduced by @ruriky in #20 

I've changed the resource titles introduced in that PR to be the namevars, didn't see much point in having "Remove " in the title, it just gets confusing IMO - otherwise that's imported as is and this PR also adds some more rspec testing around `db2::install`

Closes #20 

