### PR TITLE
Feature/manage instance service

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ db2::install { '11.1':
 * `instance_user_uid`: UID of the instance user
 * `instance_user_gid`: GID of the instance user 
 * `instance_user_home`: Home directory of the instance user
+* `manage_service`: Whether or not to manage the service for the instance (default: false)
 * `type`: Type of product this instance is for (default: ese)
 * `auth`: Type of auth for this instance (default: server)
 * `users_forcelocal`: Force the creation of instance and fence users to be local, true or false. (default: undef)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ db2::install { '11.1':
 * `instance_user_gid`: GID of the instance user 
 * `instance_user_home`: Home directory of the instance user
 * `manage_service`: Whether or not to manage the service for the instance (default: false)
+* `service_enable`: If the service is managed, whether or not it should be registered for startup on server start (default: true)
+* `service_ensure`: If the service is managed, whether or not puppet should make sure it is running (default: undef)
 * `type`: Type of product this instance is for (default: ese)
 * `auth`: Type of auth for this instance (default: server)
 * `users_forcelocal`: Force the creation of instance and fence users to be local, true or false. (default: undef)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,13 +14,17 @@ class db2 (
   $instances     = {},
   $workspace     = '/var/puppet_db2',
 ) {
-
   ensure_resource('file', $workspace, { 'ensure' => 'directory' })
 
   create_resources('db2::install', $installations)
   create_resources('db2::instance', $instances)
 
   Db2::Install<||> -> Db2::Instance<||>
+
+  exec{'db2_systemd_daemon_reload':
+    command     => '/usr/bin/systemctl daemon-reload',
+    refreshonly => true,
+  }
 
 }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -8,6 +8,7 @@ define db2::instance (
   $instance_user        = $name,
   $manage_fence_user    = true,
   $manage_instance_user = true,
+  $manage_service       = false,
   $fence_user_uid       = undef,
   $fence_user_gid       = undef,
   $fence_user_home      = undef,
@@ -43,6 +44,35 @@ define db2::instance (
       home       => $instance_user_home,
       forcelocal => $users_forcelocal,
       managehome => true,
+    }
+  }
+
+  if $manage_service {
+    if $instance_user_home == undef{
+      fail('Please set instance_user_home in order to manage the db2 service instance')
+    }
+
+    $instance_service = "db2_${name}.service"
+
+    file{"/etc/systemd/system/${instance_service}":
+      ensure  => present,
+      content => template('db2/db2_instance.service.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      notify  => Exec['db2_systemd_daemon_reload'],
+    }
+
+    service{$instance_service:
+      ensure    => 'running',
+      enable    => true,
+      subscribe => [
+        Exec['db2_systemd_daemon_reload'],
+        Db2_instance[$instance_user],
+        Db2_catalog_node[keys($catalog_nodes)],
+        Db2_catalog_database[keys($catalog_databases)],
+        Db2_catalog_dcs[keys($catalog_dcs)],
+      ],
     }
   }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -9,6 +9,8 @@ define db2::instance (
   $manage_fence_user    = true,
   $manage_instance_user = true,
   $manage_service       = false,
+  $service_ensure       = undef,
+  $service_enable       = true,
   $fence_user_uid       = undef,
   $fence_user_gid       = undef,
   $fence_user_home      = undef,
@@ -64,13 +66,13 @@ define db2::instance (
     }
 
     service{$instance_service:
-      ensure    => 'running',
-      enable    => true,
+      ensure    => $service_ensure,
+      enable    => $service_enable,
       subscribe => [
         Exec['db2_systemd_daemon_reload'],
         Db2_instance[$instance_user],
       ],
-      require => [
+      require   => [
         Db2_catalog_node[keys($catalog_nodes)],
         Db2_catalog_database[keys($catalog_databases)],
         Db2_catalog_dcs[keys($catalog_dcs)],

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -69,6 +69,8 @@ define db2::instance (
       subscribe => [
         Exec['db2_systemd_daemon_reload'],
         Db2_instance[$instance_user],
+      ],
+      require => [
         Db2_catalog_node[keys($catalog_nodes)],
         Db2_catalog_database[keys($catalog_databases)],
         Db2_catalog_dcs[keys($catalog_dcs)],

--- a/templates/db2_instance.service.erb
+++ b/templates/db2_instance.service.erb
@@ -1,0 +1,23 @@
+[Unit]
+ Description=DB2 Database Instance <%= @name %>
+ After=network.target
+
+[Service]
+ Type=forking
+ User=<%= @instance_user_uid || @instance_user %>
+<%- if @instance_user_gid -%>
+ Group=<%= @instance_user_gid %>
+<%- end -%>
+ StandardOutput=syslog
+ StandardError=syslog
+ SyslogIdentifier=db2
+ ExecStart=<%= File.join(@instance_user_home, 'sqllib/adm/db2start') %>
+ ExecStop=<%= File.join(@instance_user_home, 'sqllib/adm/db2stop') %>
+ Environment="DB2INSTANCE=<%= @name %>"
+ Environment="DB2LIB=<%= File.join(@instance_user_home, 'sqllib/lib') %>"
+ Environment="DB2_HOME=<%= File.join(@instance_user_home, 'sqllib') %>"
+ Restart=always
+
+[Install]
+ WantedBy=multi-user.target
+


### PR DESCRIPTION
This is an optional setting to manage the db2 instances service with systemd. It is disabled by default to retain backward compatibility to previous configurations.