### PR TITLE
New instance parameter 'additional_groups'

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ db2::install { '11.1':
 * `instance_user_uid`: UID of the instance user
 * `instance_user_gid`: GID of the instance user 
 * `instance_user_home`: Home directory of the instance user
+* `groups`: An array of supplementary groups for instance and fence users (optional, default: undef)
 * `type`: Type of product this instance is for (default: ese)
 * `auth`: Type of auth for this instance (default: server)
 * `users_forcelocal`: Force the creation of instance and fence users to be local, true or false. (default: undef)

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -14,6 +14,7 @@ define db2::instance (
   $instance_user_uid    = undef,
   $instance_user_gid    = undef,
   $instance_user_home   = undef,
+  $groups               = undef,
   $users_forcelocal     = undef,
   $port                 = undef,
   $type                 = 'ese',
@@ -32,6 +33,7 @@ define db2::instance (
         home       => $fence_user_home,
         forcelocal => $users_forcelocal,
         managehome => true,
+        groups     => $groups,
       }
     }
   }
@@ -43,6 +45,7 @@ define db2::instance (
       home       => $instance_user_home,
       forcelocal => $users_forcelocal,
       managehome => true,
+      groups     => $groups,
     }
   }
 

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -69,12 +69,14 @@ describe "db2::instance" do
       :fence_user_uid => '1002',
       :fence_user_gid => 'db2fencg',
       :fence_user_home => '/db2/fence',
+      :groups => 'db2group',
     }}
     it do
       is_expected.to contain_user('db2inst').with(
         :uid => '1001',
         :gid => 'db2instg',
-        :home => '/db2/inst'
+        :home => '/db2/inst',
+        :groups => 'db2group',
       )
     end
     it do
@@ -82,6 +84,7 @@ describe "db2::instance" do
         :uid => '1002',
         :gid => 'db2fencg',
         :home => '/db2/fence',
+        :groups => 'db2group',
       )
     end
   end


### PR DESCRIPTION
User can define additional groups for instance and fenced users.
Multiple groups can be defined as an array.

This change was needed because our db2 users need be able to become instance and fenced users using sudo command. There is an easy way of allowing users to become other users which are in the same group.