### PR TITLE
Additional groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ db2::install { '11.1':
 * `instance_user_uid`: UID of the instance user
 * `instance_user_gid`: GID of the instance user 
 * `instance_user_home`: Home directory of the instance user
+* `groups`: An array of supplementary groups for instance and fence users (optional, default: undef)
 * `type`: Type of product this instance is for (default: ese)
 * `auth`: Type of auth for this instance (default: server)
 * `users_forcelocal`: Force the creation of instance and fence users to be local, true or false. (default: undef)

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -14,6 +14,7 @@ define db2::instance (
   $instance_user_uid    = undef,
   $instance_user_gid    = undef,
   $instance_user_home   = undef,
+  $groups               = undef,
   $users_forcelocal     = undef,
   $port                 = undef,
   $type                 = 'ese',
@@ -32,6 +33,7 @@ define db2::instance (
         home       => $fence_user_home,
         forcelocal => $users_forcelocal,
         managehome => true,
+        groups     => $groups,
       }
     }
   }
@@ -43,6 +45,7 @@ define db2::instance (
       home       => $instance_user_home,
       forcelocal => $users_forcelocal,
       managehome => true,
+      groups     => $groups,
     }
   }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -36,6 +36,13 @@ define db2::instance (
         groups     => $groups,
       }
     }
+    if $groups {
+      $groups.each |$group| {
+        Group <| title == $group |> {
+          members +> $fence_user,
+        }
+      }
+    }
   }
   if $manage_instance_user {
     user { $instance_user:
@@ -46,6 +53,13 @@ define db2::instance (
       forcelocal => $users_forcelocal,
       managehome => true,
       groups     => $groups,
+    }
+    if $groups {
+      $groups.each |$group| {
+        Group <| title == $group |> {
+          members +> $instance_user,
+        }
+      }
     }
   }
 

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -41,7 +41,7 @@ describe "db2::instance" do
     end
   end
   context "when declared with fence user" do
-    let(:params) {{ 
+    let(:params) {{
       :installation_root => '/opt/ibm/db2/V11.1',
       :fence_user => 'db2fence'
     }}
@@ -60,7 +60,7 @@ describe "db2::instance" do
     end
   end
   context "when declaring user attributes" do
-    let(:params) {{ 
+    let(:params) {{
       :installation_root => '/opt/ibm/db2/V11.1',
       :fence_user => 'db2fence',
       :instance_user_uid => '1001',
@@ -90,7 +90,7 @@ describe "db2::instance" do
   end
 
   context "when declaring with manage_instance_user falsified" do
-    let(:params) {{ 
+    let(:params) {{
       :installation_root => '/opt/ibm/db2/V11.1',
       :fence_user => 'db2fence',
       :manage_instance_user => false,
@@ -111,7 +111,7 @@ describe "db2::instance" do
   end
 
   context "when declaring with manage_fence_user falsified" do
-    let(:params) {{ 
+    let(:params) {{
       :installation_root => '/opt/ibm/db2/V11.1',
       :fence_user => 'db2fence',
       :manage_fence_user => false,
@@ -132,7 +132,7 @@ describe "db2::instance" do
   end
 
   context "when setting the installation type and auth options" do
-    let(:params) {{ 
+    let(:params) {{
       :installation_root => '/opt/ibm/db2/V11.1',
       :fence_user => 'db2fence',
       :type       => 'standalone',
@@ -148,7 +148,7 @@ describe "db2::instance" do
   end
 
   context "when setting the port option" do
-    let(:params) {{ 
+    let(:params) {{
       :installation_root => '/opt/ibm/db2/V11.1',
       :fence_user => 'db2fence',
       :type       => 'standalone',
@@ -165,11 +165,37 @@ describe "db2::instance" do
     end
   end
 
-      
-    
+  context "when the group is not defined" do
+    let(:params) {{
+      :installation_root => '/opt/ibm/db2/V11.1',
+      :fence_user => 'db2fence',
+      :manage_fence_user => true,
+      :instance_user => 'db2inst',
+      :manage_instance_user => true,
+      :groups => ['db2group'],
+    }}
+    it do
+      is_expected.to_not contain_group('db2group').with(
+        :members => ['bob', 'db2fence', 'db2inst'],
+      )
+    end
+  end
 
+  context "when the group is already defined" do
+    let(:pre_condition) {"group {'db2group': members => ['bob']}"}
+    let(:params) {{
+      :installation_root => '/opt/ibm/db2/V11.1',
+      :fence_user => 'db2fence',
+      :manage_fence_user => true,
+      :instance_user => 'db2inst',
+      :manage_instance_user => true,
+      :groups => ['db2group'],
+    }}
+    it do
+      is_expected.to contain_group('db2group').with(
+        :members => ['bob', 'db2fence', 'db2inst'],
+      )
+    end
+  end
 
 end
-
-
-

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -69,12 +69,14 @@ describe "db2::instance" do
       :fence_user_uid => '1002',
       :fence_user_gid => 'db2fencg',
       :fence_user_home => '/db2/fence',
+      :groups => 'db2group',
     }}
     it do
       is_expected.to contain_user('db2inst').with(
         :uid => '1001',
         :gid => 'db2instg',
-        :home => '/db2/inst'
+        :home => '/db2/inst',
+        :groups => 'db2group',
       )
     end
     it do
@@ -82,6 +84,7 @@ describe "db2::instance" do
         :uid => '1002',
         :gid => 'db2fencg',
         :home => '/db2/fence',
+        :groups => 'db2group',
       )
     end
   end


### PR DESCRIPTION
There is a problem with the additional groups when the group itself is already defined somewhere else, for example with the accounts module and the member list is authoritative (auth_membership => true). In this case the user resource and the group resource will fight over the members list.

The user resource will append the user to the list and in the next run the group resource will remove it again to make sure the list only contains the members specified.

This PR extends the PR https://github.com/crayfishx/puppet-db2/pull/27 with some resource collectors that make sure the users are appended to the group resources if they exist.