### PR TITLE
set security value as upcase

### DIFF
--- a/lib/puppet/type/db2_catalog_node.rb
+++ b/lib/puppet/type/db2_catalog_node.rb
@@ -66,7 +66,7 @@ Puppet::Type.newtype(:db2_catalog_node) do
   newproperty(:security) do
     desc "Specifies the node will be security enabled, valid values are ssl, ns and server"
     munge do |value|
-      value.downcase
+      value.upcase
     end
   end
 


### PR DESCRIPTION
At the moment the security variable is set in lower/downcase, but its read in uppercase. DB2 itself also stores the value in uppercase only, even if you set it in lowercase.

example:
```
f00@f00:~> db2 list node directory show detail | grep Security
 Security type                  = SSL

```

read:
https://github.com/crayfishx/puppet-db2/blob/5763b248f603d1eae7d38bd622e912802cb630cb/lib/puppet/provider/db2_catalog_node/db2.rb#L59

write:
https://github.com/crayfishx/puppet-db2/blob/5763b248f603d1eae7d38bd622e912802cb630cb/lib/puppet/type/db2_catalog_node.rb#L66-L71

Therefore the value differs on every run and the module tries to fix it:
```
f00:~ # puppet agent --enable; puppet agent -tv; puppet agent --disable
[...]
Notice: /Stage[main]/Fleetboard::Profiles::Db2_catalog/Db2_catalog_node[ZU5AD000]/security: security changed 'SSL' to 'ssl' (corrective)
Notice: Applied catalog in 11.46 seconds

f00:~ # puppet agent --enable; puppet agent -tv; puppet agent --disable
[...]
Notice: /Stage[main]/Fleetboard::Profiles::Db2_catalog/Db2_catalog_node[ZU5AD000]/security: security changed 'SSL' to 'ssl' (corrective)
Notice: Applied catalog in 11.76 seconds
```

This change sets the value in uppercase so it matches the DB2 output and stays the same between puppet runs.