### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "crayfishx/db2",
+  "name": "crayfishx-db2",
   "version": "1.3.1",
   "author": "crayfishx",
   "summary": "Manage DB2 server and client installation and instances",


### PR DESCRIPTION
According to the specs (https://puppet.com/docs/puppet/7.4/modules_metadata.html) name should use dash as separator not slash. This triggers an error when doing a metadata-json-lont on this module. It als prevents our IDE (RubyMine) from correctly resolving module dependencies.