### PR TITLE
Update metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "crayfishx/db2",
+  "name": "crayfishx-db2",
   "version": "1.3.1",
   "author": "crayfishx",
   "summary": "Manage DB2 server and client installation and instances",
@@ -32,9 +32,8 @@
   "project_page": "https://github.com/crayfishx/puppet-db2",
   "issues_url": "https://github.com/crayfishx/puppet-db2/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.11.0 < 5.0.0"},
-    {"name":"puppet-archive","version_requirement":">= 0.5.0 < 2.0.0"}
-  ],
-  "data_provider": null
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.11.0 < 10.0.0"},
+    {"name":"puppet-archive","version_requirement":">= 0.5.0 < 8.0.0"}
+  ]
 }
 


### PR DESCRIPTION
According to the specs (https://puppet.com/docs/puppet/7.4/modules_metadata.html) name should use dash as separator not slash. This triggers an error when doing a metadata-json-lont on this module. It als prevents our IDE (RubyMine) from correctly resolving module dependencies. Also allow latest dependencies.